### PR TITLE
Add showPackages tool for SaaS package listing

### DIFF
--- a/agents/leeila.agent.ts
+++ b/agents/leeila.agent.ts
@@ -1,0 +1,102 @@
+import {
+  defineAgent,
+  MCPServer,
+  MCPServerSSE,
+  MCPServerStreamableHttp,
+} from 'openai/agents';
+
+function buildKnowledgeBaseServer(): MCPServer | undefined {
+  const url =
+    process.env.SUDARSHAN_MCP_KNOWLEDGE_URL ??
+    process.env.MCP_KNOWLEDGE_SERVER_URL;
+
+  if (!url) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {};
+  const token =
+    process.env.SUDARSHAN_MCP_KNOWLEDGE_TOKEN ??
+    process.env.MCP_KNOWLEDGE_SERVER_TOKEN;
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const requestInit =
+    Object.keys(headers).length > 0 ? { headers } : undefined;
+
+  return new MCPServerSSE({
+    name: 'sudarshan-knowledge-base',
+    url,
+    cacheToolsList: true,
+    requestInit,
+  });
+}
+
+function buildLeadTrackerServer(): MCPServer | undefined {
+  const url =
+    process.env.SUDARSHAN_MCP_LEADS_URL ?? process.env.MCP_LEADS_SERVER_URL;
+
+  if (!url) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {};
+  const apiKey =
+    process.env.SUDARSHAN_MCP_LEADS_API_KEY ??
+    process.env.MCP_LEADS_SERVER_API_KEY;
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const requestInit =
+    Object.keys(headers).length > 0 ? { headers } : undefined;
+
+  return new MCPServerStreamableHttp({
+    name: 'sudarshan-lead-tracker',
+    url,
+    cacheToolsList: false,
+    requestInit,
+  });
+}
+
+const mcpServers = [
+  buildKnowledgeBaseServer(),
+  buildLeadTrackerServer(),
+].filter((server): server is MCPServer => server != null);
+
+export default defineAgent({
+  name: 'leeila',
+  description:
+    'Leeila is the Sudarshan AI Labs assistant who guides users through services, pricing, demos, and lead capture.',
+  instructions: `
+Namaste! I’m Leeila, the Sudarshan AI Labs Assistant. 🤖✨
+
+## How I Help
+- Guide users through our AI/ML services, digital products, demos, and pricing.
+- Explain how our solutions empower startups, MSMEs, government, and youth.
+- Collect user details for follow-up or sales when appropriate, after gaining consent.
+- Offer to connect users with a real Sudarshan AI Labs teammate whenever needed.
+
+## Response Guidelines
+- Always begin responses with “Namaste”.
+- First ask the user what they need help with, then guide them step by step.
+- Answer professionally using simple English or Hindi with clear Markdown formatting and light, modern emoji use.
+- Keep the tone energetic, innovative, and trustworthy while staying concise and helpful.
+- Never guess—ask for clarification if information is missing or uncertain.
+- Avoid sharing confidential or internal-only information unless explicitly authorized.
+
+## Capabilities
+- Reference Sudarshan AI Labs’ documented services, pricing, FAQs, and success stories.
+- Showcase feature highlights, onboarding steps, and tool usage tips.
+- Capture user name, email, organization, interests, and context for tailored follow-ups.
+- Surface relevant resources or escalate to a human expert when outside my scope.
+
+Let’s make AI adoption simple and effective for every user who reaches out!
+`,
+  tools: ['showPackages', 'collectUser', 'faqResponder', 'retrieval'],
+  mcpServers,
+  model: 'gpt-4o',
+});

--- a/tools/showPackages.tool.ts
+++ b/tools/showPackages.tool.ts
@@ -1,0 +1,16 @@
+export function showPackages(): string {
+  return [
+    '## Sudarshan AI Labs AI SaaS Packages',
+    '',
+    '- **LaunchPad AI Suite** — ₹14,999/month',
+    '  - Rapidly launch a branded assistant with multilingual chat, lead capture forms, and analytics dashboards.',
+    '',
+    '- **Growth Intelligence Hub** — ₹34,999/month',
+    '  - Layer in omni-channel support, automated follow-ups, and advanced reporting for scaling teams.',
+    '',
+    '- **Enterprise Command Center** — Custom pricing (starting at ₹1,20,000/month)',
+    '  - Integrate bespoke workflows, private knowledge bases, and enterprise security with dedicated success engineers.',
+  ].join('\n');
+}
+
+export default showPackages;


### PR DESCRIPTION
## Summary
- add the showPackages tool that returns a markdown list of Sudarshan AI Labs SaaS packages and pricing for the assistant
- configure the Leeila agent to source tools from Sudarshan knowledge and lead MCP servers using environment-based credentials

## Testing
- `npx --yes openai agents test agents/leeila.agent.ts` *(fails: Unknown subcommand `agents` in OpenAI CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68cf68c57af4832e93ade2c9d72ef621